### PR TITLE
Generate parallella dtbs when running `make dtbs`

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -323,6 +323,8 @@ dtb-$(CONFIG_ARCH_ZYNQ) += zynq-zc702.dtb \
 			zynq-afx-nand.dtb \
 			zynq-afx-nor.dtb \
 			zynq-cc108.dtb \
+			zynq-parallella1-hdmi.dtb \
+			zynq-parallella1-headless.dtb \
 			zynq-zc770-xm010.dtb \
 			zynq-zc770-xm011.dtb \
 			zynq-zc770-xm012.dtb \


### PR DESCRIPTION
Signed-off-by: Daniel Cordero <parallella@xxoo.ws>