### PR TITLE
ARM: dts: zynq: parallella: Fix up reserved-memory and memory nodes

### DIFF
--- a/arch/arm/boot/dts/zynq-parallella1.dtsi
+++ b/arch/arm/boot/dts/zynq-parallella1.dtsi
@@ -31,16 +31,16 @@
 
 	memory {
 		device_type = "memory";
-		reg = <0x0 0x3e000000>;
+		reg = <0x0 0x40000000>;
 	};
 
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
-		no-map;
-		emem: emem@3e00000 {
+		emem: emem@3e000000 {
 			reg = <0x3e000000 0x2000000>;
+			no-map;
 		};
 	};
 


### PR DESCRIPTION
This pull request resolves issues where the reserved memory region is not available to the elink driver.

```
[    1.777966] elink 81000000.elink0: reserved-mem: failed requesting mem region
[    1.785062] elink 81000000.elink0: reserved mem probe failed
[    1.790665] elink 81000000.elink0: Failed parsing device tree
[    1.796490] elink: probe of 81000000.elink0 failed with error -12
```

With these changes the reserved memory is now available for request by the driver, and allows for the driver to probe correctly.

```
[    1.853077] epiphany elink0: elink: version field empty. Using default platform.
[    1.853095] epiphany elink0: Epiphany FPGA elink at address 0x81000000
[    1.853095] epiphany elink0: platform 01 revision 00
```

```
root@parallella:~# cat /proc/iomem
00000000-3dffffff : System RAM
  00208000-00e5bf37 : Kernel code
  00f64000-010b1b57 : Kernel data
3e000000-3fffffff : 81000000.elink0
80000000-8fffffff : 81000000.elink0
...
```
